### PR TITLE
Changes for deploying with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.semaphore-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ MarkupSafe==1.1.1
 more-itertools==7.2.0
 ordered-set==3.1.1
 numpy==1.16.0
-pandas==0.23.4
+pandas==1.1.0
 pyecore==0.11.1
 pyrsistent==0.15.4
 python-dateutil==2.8.0


### PR DESCRIPTION
These are some changes necessary to build the Docker container on both my local machine, and when deploying to our servers. I'm not sure if I should be sending this PR to quintel/etm-esdl or mondaine-esdl/etm-esdl. I opted for the former, since that what's used to build the docker images for deployment.

* Bump Pandas to 1.1.0, as the Docker build would fail every time with 0.23.4.
* Adds .semaphore-cache to the dockerignore file so that it does a fresh build every time (I'm not clear if this is necessary, but the Semaphore docs recommended it).