### PR TITLE
Attempted fix to support HTTPS proxying

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, Blueprint
 from flask_restplus import Api, Resource, fields
+from werkzeug.middleware.proxy_fix import ProxyFix
 from helpers.energy_system_handler import EnergySystemHandler
 from helpers.MondaineHub import MondaineHub
 from interface import translate_esdl_to_slider_settings, translate_kpis_to_esdl
@@ -91,5 +92,6 @@ class EnergySystem(Resource):
 
 if __name__ == '__main__':
     app = Flask(__name__)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_host=1, x_proto=1)
     app.register_blueprint(api_v1)
     app.run(host='0.0.0.0', debug=True)


### PR DESCRIPTION
My attempts to enable the etm-esdl app over HTTPS haven't worked, with the app showing "No API definition provided.".

I think this is due to the app expecting HTTP only (that's how it's running in the Docker container). [I found this fix](https://github.com/noirbizarre/flask-restplus/issues/565#issuecomment-562610603); I'm not familiar with Flask/Swagger, but it seems like it should fix the problem when deployed.

I ran the app locally and it at least doesn't seem to have broken anything.

See: [About ProxyFix](https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/).