### PR TITLE
Quick and dirty fix for parsing hybrid heat pumps

### DIFF
--- a/config/assets.py
+++ b/config/assets.py
@@ -47,6 +47,24 @@ distributions = {
 
 heating_technologies = {
     'HeatPump': [
+        { # Hybride warmtepomp op methaan
+            'attribute': 'additionalHeatingSourceType',
+            'value': 'GAS',
+            'inputs': { # dependent on building types
+                'RESIDENTIAL': 'households_heater_hybrid_heatpump_air_water_electricity_share',
+                'UTILITY': 'buildings_space_heater_heatpump_air_water_network_gas_share'
+            },
+            'aggregation': 'sum'
+        },
+        { # Hybride warmtepomp op waterstof
+            'attribute': 'additionalHeatingSourceType',
+            'value': 'HYDROGEN',
+            'inputs': { # dependent on building types
+                'RESIDENTIAL': 'households_heater_hybrid_hydrogen_heatpump_air_water_electricity_share',
+                'UTILITY': 'buildings_space_heater_heatpump_air_water_network_gas_share'
+            },
+            'aggregation': 'sum'
+        },
         { # Elektrische luchtwarmtepomp
             'attribute': 'source',
             'value': 'AIR',
@@ -71,24 +89,6 @@ heating_technologies = {
             'inputs': { # dependent on building types
                 'RESIDENTIAL': 'households_heater_heatpump_ground_water_electricity_share',
                 'UTILITY': 'buildings_space_heater_collective_heatpump_water_water_ts_electricity_share'
-            },
-            'aggregation': 'sum'
-        },
-        { # Hybride warmtepomp op methaan
-            'attribute': 'additionalHeatingSourceType',
-            'value': 'GAS',
-            'inputs': { # dependent on building types
-                'RESIDENTIAL': 'households_heater_hybrid_heatpump_air_water_electricity_share',
-                'UTILITY': 'buildings_space_heater_heatpump_air_water_network_gas_share'
-            },
-            'aggregation': 'sum'
-        },
-        { # Hybride warmtepomp op waterstof
-            'attribute': 'additionalHeatingSourceType',
-            'value': 'HYDROGEN',
-            'inputs': { # dependent on building types
-                'RESIDENTIAL': 'households_heater_hybrid_hydrogen_heatpump_air_water_electricity_share',
-                'UTILITY': 'buildings_space_heater_heatpump_air_water_network_gas_share'
             },
             'aggregation': 'sum'
         }


### PR DESCRIPTION
Change the order of heating technologies in the config file (put hybrid heat pumps above regular heat pumps). This results in the hybrid heat pumps being checked first. 