### PR TITLE
Collect ecore resource in tmp folder on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ KPIs.esdl
 venv
 __pycache__
 .pytest_cache
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
 FROM python:3.8-alpine
 LABEL Author='Roos de Kok  <roos.dekok@quintel.com>'
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
 RUN apk add --update alpine-sdk
 RUN apk add --update --no-cache libxslt-dev libxml2-dev
 
+RUN pip install pipenv
+
+# -- Install Application into container:
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+# -- Adding Pipfiles and installing a virtual environment
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN pip install --upgrade pip && \
-    pip install pipenv && \
-    pipenv install --system --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
+# -- Copy Application
 COPY . .
 
+# -- Fetch ecore resource
+RUN pipenv run fetch_esdl_ecore_resource
+
+# -- Set Environment
 ENV PYTHONPATH=.:/usr/src/app
 ENV FLASK_APP "app"
 
+# -- Launch app
 EXPOSE 5000
-
-CMD cd /usr/src/app && flask run --host=0.0.0.0
+CMD pipenv run flask run --host=0.0.0.0

--- a/Pipfile
+++ b/Pipfile
@@ -21,3 +21,5 @@ python_version = "3.8"
 
 [scripts]
 test = "python -m pytest"
+# Fetches the esdl ecore resource from git (optional commit hash argument)
+fetch_esdl_ecore_resource = "python lib/tasks/fetch_esdl_resource.py 966707e"

--- a/app/helpers/energy_system_handler.py
+++ b/app/helpers/energy_system_handler.py
@@ -19,8 +19,8 @@ class EnergySystemHandler:
         # Assign files with the .esdl extension to the XMLResource instead of default XMI
         self.rset.resource_factory['esdl'] = lambda uri: XMLResource(uri)
 
-        # Read the lastest esdl.ecore from github
-        esdl_model_resource = self.rset.get_resource(HttpURI('https://raw.githubusercontent.com/EnergyTransition/ESDL/master/esdl/model/esdl.ecore'))
+        # Read the esdl.ecore from the tmp folder
+        esdl_model_resource = self.rset.get_resource(URI('tmp/esdl/esdl.ecore'))
 
         esdl_model = esdl_model_resource.contents[0]
         # print('Namespace: {}'.format(esdl_model.nsURI))

--- a/lib/tasks/fetch_esdl_resource.py
+++ b/lib/tasks/fetch_esdl_resource.py
@@ -1,0 +1,28 @@
+'''
+Downloads the ecore esdl resource from github into the lib folder. This xml-file is needed as a
+resource for the EnergySystemHandler
+'''
+import requests
+import sys
+import os
+
+TMP_FOLDER_PATH = 'tmp/esdl/'
+ECORE_FILE_PATH = TMP_FOLDER_PATH + 'esdl.ecore'
+
+if __name__ == "__main__":
+    commit_hash = sys.argv[0] if len(sys.argv) == 1 else ''
+
+    if commit_hash:
+        github_url = f'https://raw.githubusercontent.com/EnergyTransition/ESDL/#{commit_hash}/esdl/model/esdl.ecore'
+    else:
+        github_url = 'https://raw.githubusercontent.com/EnergyTransition/ESDL/master/esdl/model/esdl.ecore'
+
+    result = requests.get(github_url)
+
+    if result.ok:
+        os.makedirs(TMP_FOLDER_PATH, exist_ok=True)
+
+        with open(ECORE_FILE_PATH, 'wb') as file:
+            file.write(result.content)
+    else:
+        raise ValueError(f'Could not fetch ESDL ecore resource from github #{commit_hash}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,17 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 # pylint: disable=wrong-import-position, disable=import-error, disable=redefined-outer-name
 from app import create_app
 
+@pytest.fixture(scope='session', autouse=True)
+def precondition():
+    ''' Runs before tests, checks if preconditions are met'''
+    ecore_resource = 'tmp/esdl/esdl.ecore'
+    if not path.exists(ecore_resource):
+        pytest.exit(
+            'No ecore resource was found, please run "pipenv run fetch_esdl_ecore_resource" ' +
+            'before running tests'
+        )
+
+
 @pytest.fixture
 def app():
     '''Fixture for the application'''


### PR DESCRIPTION
The ecore resource now has version control, you can specify the specific commit in the Pipfile.
According to pipenvs best-practices, also run a virtual environment inside the Docker container.
Test suite will fail if you did not yet collect the ecore resource.

Closes #26 