### PR TITLE
Add Sentry to the app for staging and production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 __pycache__
 .pytest_cache
 tmp
+.env

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ lxml = "*"
 more-itertools = "*"
 requests = "*"
 Flask = "~=1.1.1"
+'sentry-sdk[flask]' = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "871bd9e95ffffa0be4ae5ba3e4c2496faa4ca51a2329db1d4b90df18f06d6608"
+            "sha256": "1b2f18d280802c4ff1ae360e933b6b8e3e2ebe7fa7f3493383d87bbf9e84a913"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,6 +21,7 @@
                 "sha256:1d2b7ef82963909e93c4f24ce48d4de9e66009a21bf1c1e1c85bdd0812fe412f",
                 "sha256:72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==9.0.1"
         },
         "attrs": {
@@ -30,6 +31,12 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
+        },
+        "blinker": {
+            "hashes": [
+                "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
+            ],
+            "version": "==1.4"
         },
         "certifi": {
             "hashes": [
@@ -64,11 +71,11 @@
         },
         "flask-restx": {
             "hashes": [
-                "sha256:a1653da19ca0b5e5c2ea59bd5f4639a7749e6a9b882f459de1814ed37872253b",
-                "sha256:ca87a1808333f4ec5a50a5740b44e6cd3879a4b940d559df3996877ec4a2f2a5"
+                "sha256:77cb990d16b36b22582c48b42b8841130b80c18d1e2f7c8a361d96d238d5327c",
+                "sha256:8796145aca9e62aba12f8859fba8c591b49c850a8fdb6d8b56459d7a8014ca24"
             ],
             "index": "pypi",
-            "version": "==0.2.0"
+            "version": "==0.3.0"
         },
         "idna": {
             "hashes": [
@@ -118,6 +125,7 @@
                 "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83",
                 "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04",
                 "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791",
+                "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51",
                 "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1",
                 "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a",
                 "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f",
@@ -136,7 +144,8 @@
                 "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0",
                 "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654",
                 "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2",
-                "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23"
+                "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23",
+                "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"
             ],
             "index": "pypi",
             "version": "==4.6.3"
@@ -252,6 +261,17 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '3.10'",
             "version": "==5.1"
         },
+        "sentry-sdk": {
+            "extras": [
+                "flask"
+            ],
+            "hashes": [
+                "sha256:71de00c9711926816f750bc0f57ef2abbcb1bfbdf5378c601df7ec978f44857a",
+                "sha256:9221e985f425913204989d0e0e1cbb719e8b7fa10540f1bc509f660c06a34e66"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -280,11 +300,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:21d735aab248253531bb0f1e1e6d068f0ee23533e18ae8a6171ff892b98297cf",
-                "sha256:cfc35498ee64017be059ceffab0a25bedf7548ab76f2bea691c5565896e7128d"
+                "sha256:6b0ed1af831570e500e2437625979eaa3b36011f66ddfc4ce930128610258ca9",
+                "sha256:cd80bf957c49765dce6d92c43163ff9d2abc43132ce64d4b1b47717c6d2522df"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.5.1"
+            "version": "==2.5.2"
         },
         "attrs": {
             "hashes": [
@@ -393,11 +413,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a",
-                "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"
+                "sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a",
+                "sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee"
             ],
             "index": "pypi",
-            "version": "==2.7.2"
+            "version": "==2.7.4"
         },
         "pyparsing": {
             "hashes": [

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,8 +4,13 @@ Initializes the app and sets up all the routes
 
 import os
 
+## Sentry ##
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+## App
 from flask import Flask, jsonify
-from werkzeug.middleware.proxy_fix import ProxyFix
+# from werkzeug.middleware.proxy_fix import ProxyFix
 from config import *
 from app.helpers.exceptions import EnergysystemParseError
 from app.api import blueprint as api
@@ -29,6 +34,12 @@ def create_app(testing=False):
         app.config.from_object(TestingConfig())
     elif environment == 'production':
         app.config.from_object(ProductionConfig())
+        # Set up Sentry
+        sentry_sdk.init(os.environ.get('SENTRY_DSN'), integrations=[FlaskIntegration()])
+    elif environment == 'staging':
+        app.config.from_object(StagingConfig())
+        # Set up Sentry
+        sentry_sdk.init(os.environ.get('SENTRY_DSN'), integrations=[FlaskIntegration()])
     elif environment == 'development':
         app.config.from_object(DevelopmentConfig())
     else:

--- a/config.py
+++ b/config.py
@@ -16,6 +16,9 @@ class Config(object):
 class ProductionConfig(Config):
     ''' Use the defaults for production'''
 
+class StagingConfig(ProductionConfig):
+    ''' Use the production defaults for staging'''
+
 class DevelopmentConfig(Config):
     '''Sets debug to true'''
     DEBUG = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+''' Tests for config '''
+# pylint: disable=import-error
+from config import ProductionConfig
+
+def test_production():
+    ''' Test production config '''
+    production_config = ProductionConfig()
+
+    assert 'beta' in production_config.ETENGINE.keys()
+    assert production_config.DEBUG is False
+    assert production_config.TESTING is False


### PR DESCRIPTION
Adds support for Sentry in staging and production environments. The DSN should be added to the environment variables in `docker-compose.yml`

```
services:
    my_service:
        environment:
             SENTRY_DSN: <my_sentry_dsn>
```