### PR TITLE
Add Electrolyzer parser

### DIFF
--- a/app/models/esdl_to_scenario_converter.py
+++ b/app/models/esdl_to_scenario_converter.py
@@ -9,7 +9,8 @@ from app.models.balancer import Balancer
 from app.models.conversion_assets import assets, area_mapping
 from app.models.parsers import (
     EnergyLabelsParser, HeatingTechnologiesParser, VolatileParser, RooftopPVParser,
-    VolumeParser, CarrierCapacityParser, CarrierVolumeParser, SubtypeCapacityParser
+    VolumeParser, CarrierCapacityParser, CarrierVolumeParser, SubtypeCapacityParser,
+    FlexibilityParser
 )
 
 
@@ -75,6 +76,8 @@ class EsdlToScenarioConverter():
             VolatileParser(self.energy_system, asset, inputs=self.inputs).parse()
         elif asset['parser'] == 'volume':
             VolumeParser(self.energy_system, asset, inputs=self.inputs).parse()
+        elif asset['parser'] == 'flexibility':
+            FlexibilityParser(self.energy_system, asset, inputs=self.inputs).parse()
         # Watch out! we are skipping the heating_tech parser!
 
     def determine_number_of_buildings(self):

--- a/app/models/kpi_handler.py
+++ b/app/models/kpi_handler.py
@@ -41,17 +41,18 @@ class KPIHandler():
         Update the KPIs of the energy system based on ETM queries
         """
 
-        for kpi in self.energy_system.area().KPIs.kpi:
-            # TODO@Roos: if KPI is unknown -> KeyError -> 500. Is that wanted behaviour?
-            prop = kpis[kpi.id]
-            metrics = self.get_metrics(*[gquery['gquery'] for gquery in prop['gqueries']])
+        if self.energy_system.area().KPIs:
+            for kpi in self.energy_system.area().KPIs.kpi:
+                # TODO@Roos: if KPI is unknown -> KeyError -> 500. Is that wanted behaviour?
+                prop = kpis[kpi.id]
+                metrics = self.get_metrics(*[gquery['gquery'] for gquery in prop['gqueries']])
 
-            if prop['esdl_type'] == 'DistributionKPI':
-                for kpi_item in kpi.distribution.stringItem:
-                    kpi.distribution.stringItem.remove(kpi_item)
-                self.__add_results_to_kpi_distribution(kpi, prop, metrics)
-            else:
-                kpi.value = metrics[prop['gqueries'][0]['gquery']]['future'] * prop['factor']
+                if prop['esdl_type'] == 'DistributionKPI':
+                    for kpi_item in kpi.distribution.stringItem:
+                        kpi.distribution.stringItem.remove(kpi_item)
+                    self.__add_results_to_kpi_distribution(kpi, prop, metrics)
+                else:
+                    kpi.value = metrics[prop['gqueries'][0]['gquery']]['future'] * prop['factor']
 
     def add_kpis(self, description=''):
         """

--- a/app/models/parsers/__init__.py
+++ b/app/models/parsers/__init__.py
@@ -3,6 +3,7 @@
 from .carrier_volume import CarrierVolumeParser
 from .subtype_capacity import SubtypeCapacityParser
 from .energy_labels import EnergyLabelsParser
+from .flexibility import FlexibilityParser
 from .heating_technologies import HeatingTechnologiesParser
 from .rooftop_pv import RooftopPVParser
 from .carrier_capacity import CarrierCapacityParser

--- a/app/models/parsers/flexibility.py
+++ b/app/models/parsers/flexibility.py
@@ -1,0 +1,43 @@
+"""
+Parser for flexibility assets (electrolyzers)
+"""
+
+from .parser import CapacityParser
+
+class FlexibilityParser(CapacityParser):
+    """
+    Class to parse ESDL information about a single asset and
+    translate it to the relevant ETM inputs that have to do with flexibility assets.
+    Uses power to calculate the flexibility assets' inputs.
+    """
+
+    def __init__(self, energy_system, props, *args, **kwargs):
+        super().__init__(energy_system, props, *args, **kwargs)
+        self.power = 0. # is this line of code redundant?
+
+
+    def parse(self):
+        """
+        Check the total power of the given asset
+
+        Sets self.power and self.input
+        """
+
+        self.power = sum((self.__value_of(asset, 'power') for asset in self.asset_generator))
+        self.inputs[self.props['input']] = self.power
+
+
+    def __value_of(self, asset, key):
+        '''
+        Returns the value multiplied with the config factor for the key
+
+        Params:
+            asset (esdl.asset): Asset that is being parsed
+            key (str): 'power'
+
+        Returns:
+            float
+        '''
+        if key!=self.props['attribute']: return 0.0
+
+        return getattr(asset, key) * self.props['factor']

--- a/app/models/parsers/flexibility.py
+++ b/app/models/parsers/flexibility.py
@@ -15,7 +15,6 @@ class FlexibilityParser(CapacityParser):
     def __init__(self, energy_system, props, *args, **kwargs):
         super().__init__(energy_system, props, *args, **kwargs)
         self.full_load_hours = 0.
-        self.power = 0. # is this line of code redundant?
 
 
     def parse(self):
@@ -64,8 +63,7 @@ class FlexibilityParser(CapacityParser):
         """
 
         self.full_load_hours = (
-            self.query_scenario(scenario_id, self.props['attr_set']['full_load_hours']) /
-            self.props['attr_set']['fullLoadHours']['factor']
+            self.query_scenario(scenario_id, self.props['attr_set']['fullLoadHours'])
         )
 
         for asset in self.asset_generator:

--- a/app/models/parsers/flexibility.py
+++ b/app/models/parsers/flexibility.py
@@ -2,6 +2,7 @@
 Parser for flexibility assets (electrolyzers)
 """
 
+from app.services.query_scenario import QueryScenario
 from .parser import CapacityParser
 
 class FlexibilityParser(CapacityParser):
@@ -13,6 +14,7 @@ class FlexibilityParser(CapacityParser):
 
     def __init__(self, energy_system, props, *args, **kwargs):
         super().__init__(energy_system, props, *args, **kwargs)
+        self.full_load_hours = 0.
         self.power = 0. # is this line of code redundant?
 
 
@@ -24,11 +26,22 @@ class FlexibilityParser(CapacityParser):
         """
 
         self.power = sum((self.__value_of(asset, 'power') for asset in self.asset_generator))
-        self.inputs[self.props['input']] = self.power
+        self.inputs[self.props['attr_set']['power']['input']] = self.power
+
+
+    def update(self, scenario_id):
+        """
+        Find the flexibility asset and update the number of full load hours
+        with the ETM value
+
+        Sets self.full_load_hours
+        """
+
+        self.update_flh()
 
 
     def __value_of(self, asset, key):
-        '''
+        """
         Returns the value multiplied with the config factor for the key
 
         Params:
@@ -37,7 +50,42 @@ class FlexibilityParser(CapacityParser):
 
         Returns:
             float
-        '''
-        if key!=self.props['attribute']: return 0.0
+        """
 
-        return getattr(asset, key) * self.props['factor']
+        if not key in ['power', 'fullLoadHours']: return 0.0
+
+        return getattr(asset, key) * self.props['attr_set'][key]['factor']
+
+
+    def __update_flh(self, scenario_id):
+        """
+        For each instance in the list of assets of this type of supply, update
+        the number of full load hours to the ETM value.
+        """
+
+        self.full_load_hours = (
+            self.query_scenario(scenario_id, self.props['attr_set']['full_load_hours']) /
+            self.props['attr_set']['fullLoadHours']['factor']
+        )
+
+        for asset in self.asset_generator:
+            asset.fullLoadHours = self.full_load_hours
+
+
+    def __query_scenario(self, scenario_id, prop):
+        """
+        Query the ETM scenario for the value to set the given prop to
+
+        Params:
+            scenario_id (str): e.g. '123456'
+            prop (str): e.g. 'fullLoadHours'
+        """
+
+        query_result = QueryScenario.execute(scenario_id, prop['gquery'])
+
+        if query_result.successful:
+            return query_result.value[prop['gquery']]['future'] / prop ['factor']
+
+        raise ETMParseError(
+            f"We currently do not support the ETM gquery listed in the config: {prop['gquery']}"
+        )

--- a/app/models/parsers/flexibility.py
+++ b/app/models/parsers/flexibility.py
@@ -27,7 +27,6 @@ class FlexibilityParser(CapacityParser):
         self.power = sum((self.__value_of(asset, 'power') for asset in self.asset_generator))
         self.inputs[self.props['attr_set']['power']['input']] = self.power
 
-
     def update(self, scenario_id):
         """
         Find the flexibility asset and update the number of full load hours
@@ -36,7 +35,7 @@ class FlexibilityParser(CapacityParser):
         Sets self.full_load_hours
         """
 
-        self.update_flh()
+        self.__update_flh(scenario_id)
 
 
     def __value_of(self, asset, key):
@@ -63,11 +62,12 @@ class FlexibilityParser(CapacityParser):
         """
 
         self.full_load_hours = (
-            self.query_scenario(scenario_id, self.props['attr_set']['fullLoadHours'])
+            self.__query_scenario(scenario_id, self.props['attr_set']['fullLoadHours'])
         )
 
         for asset in self.asset_generator:
-            asset.fullLoadHours = self.full_load_hours
+            # ESDL expects the FLH to be an integer value
+            asset.fullLoadHours = int(self.full_load_hours)
 
 
     def __query_scenario(self, scenario_id, prop):

--- a/app/models/parsers/volatile.py
+++ b/app/models/parsers/volatile.py
@@ -49,7 +49,6 @@ class VolatileParser(CapacityParser):
         """
         Update the power and full load hours based on the ETM inputs
         """
-        self.parse()
         self.update_props(scenario_id)
 
     def __ensure_valid_props(self):
@@ -64,7 +63,7 @@ class VolatileParser(CapacityParser):
         )
 
     def __value_of(self, asset, key):
-        '''
+        """
         Returns the value multiplied with the config factor for the key
 
         Params:
@@ -73,7 +72,7 @@ class VolatileParser(CapacityParser):
 
         Returns:
             float
-        '''
+        """
         if not key in ['power', 'fullLoadHours']: return 0.0
 
         return getattr(asset, key) * self.props['attr_set'][key]['factor']
@@ -82,7 +81,8 @@ class VolatileParser(CapacityParser):
 
     def query_scenario(self, scenario_id, prop):
         """
-        TODO
+        Query the ETM scenario for the gquery value corresponding to the prop
+        that should be updated
         """
         query_result = QueryScenario.execute(scenario_id, prop['gquery'])
 
@@ -93,10 +93,11 @@ class VolatileParser(CapacityParser):
             f"We currently do not support the ETM gquery listed in the config: {prop['gquery']}"
         )
 
-
     def update_props(self, scenario_id):
         """
-        TODO
+        Update the asset props based on the ETM values.
+
+        TODO: Add measures based on the power in the ETM
         """
         # First, update the full load hours. This value is necessary for the
         # measures that follow from updating the power.
@@ -104,10 +105,10 @@ class VolatileParser(CapacityParser):
         flh_val = self.query_scenario(scenario_id, self.props['attr_set']['fullLoadHours'])
         self.update_flh(flh_val / self.props['attr_set']['fullLoadHours']['factor'])
 
-        power_val = self.query_scenario(scenario_id, self.props['attr_set']['power'])
-        diff = power_val - (self.power / self.props['attr_set']['power']['factor'])
-        if diff > 0:
-            self.add_measures(diff, self.props['attr_set']['power']['edr'])
+        # power_val = self.query_scenario(scenario_id, self.props['attr_set']['power'])
+        # diff = power_val - (self.power / self.props['attr_set']['power']['factor'])
+        # if diff > 0:
+        #     self.add_measures(diff, self.props['attr_set']['power']['edr'])
 
 
     def update_flh(self, val):
@@ -118,7 +119,7 @@ class VolatileParser(CapacityParser):
         self.full_load_hours = val
 
         for asset in self.asset_generator:
-            asset.fullLoadHours = val
+            asset.fullLoadHours = int(val)
 
 
     def remove_assets(self, diff):

--- a/app/models/scenario_to_esdl_converter.py
+++ b/app/models/scenario_to_esdl_converter.py
@@ -15,26 +15,21 @@ def update_esdl(energy_system, scenario_id):
     # Update KPIs
     KPIHandler(energy_system, scenario_id).update()
 
-    # Update capacities of wind turbines and possibly add measures
-    for asset in get_configs_for_assets('WindTurbine'):
+    # Update capacities of wind turbines, FLH for PV parks and FLH for electrolyzers;
+    # possibly add measures
+    for asset in get_configs_for_assets('WindTurbine', 'PVPark', 'Electrolyzer'):
         if asset['parser'] == 'volatile':
             VolatileParser(energy_system, asset).update(scenario_id)
-
-    # Update FLH for PV parks
-    for asset in get_configs_for_assets('PVPark'):
-        if asset['parser'] == 'volatile':
-            VolatileParser(energy_system, asset).update(scenario_id)
-
-    # Update FLH for electrolyzers
-    for asset in get_configs_for_assets('Electrolyzer'):
-        if asset['parser'] == 'flexibility':
+        elif asset['parser'] == 'flexibility':
             FlexibilityParser(energy_system, asset).update(scenario_id)
+    return energy_system
+
 
     return energy_system
 
 
-def get_configs_for_assets(asset_type):
+def get_configs_for_assets(*asset_types):
     """
     Returns a generator full of config asset with given asset type e.g. GasHeater
     """
-    return (asset for asset in assets if asset['asset'] == asset_type)
+    return (asset for asset in assets if asset['asset'] in asset_types)

--- a/app/models/scenario_to_esdl_converter.py
+++ b/app/models/scenario_to_esdl_converter.py
@@ -1,8 +1,8 @@
-'''
+"""
 Some conversion methods
-'''
+"""
 from app.models.conversion_assets import assets
-from app.models.parsers import VolatileParser
+from app.models.parsers import FlexibilityParser, VolatileParser
 from app.models.kpi_handler import KPIHandler
 
 def update_esdl(energy_system, scenario_id):
@@ -20,9 +20,21 @@ def update_esdl(energy_system, scenario_id):
         if asset['parser'] == 'volatile':
             VolatileParser(energy_system, asset).update(scenario_id)
 
+    # Update FLH for PV parks
+    for asset in get_configs_for_assets('PVPark'):
+        if asset['parser'] == 'volatile':
+            VolatileParser(energy_system, asset).update(scenario_id)
+
+    # Update FLH for electrolyzers
+    for asset in get_configs_for_assets('Electrolyzer'):
+        if asset['parser'] == 'flexibility':
+            FlexibilityParser(energy_system, asset).update(scenario_id)
+
     return energy_system
 
 
 def get_configs_for_assets(asset_type):
-    '''Returns a generator full of config asset with given asset type e.g. GasHeater'''
+    """
+    Returns a generator full of config asset with given asset type e.g. GasHeater
+    """
     return (asset for asset in assets if asset['asset'] == asset_type)

--- a/config/conversions/assets/flexibility.yml
+++ b/config/conversions/assets/flexibility.yml
@@ -1,0 +1,8 @@
+# ESDL asset conversions for flexibility assets
+
+# Electrolyzer
+- asset: Electrolyzer
+  parser: flexibility
+  attribute: power
+  input: capacity_of_energy_hydrogen_flexibility_p2g_electricity
+  factor: 1.e-6

--- a/config/conversions/assets/flexibility.yml
+++ b/config/conversions/assets/flexibility.yml
@@ -3,6 +3,13 @@
 # Electrolyzer
 - asset: Electrolyzer
   parser: flexibility
-  attribute: power
-  input: capacity_of_energy_hydrogen_flexibility_p2g_electricity
-  factor: 1.e-6
+  # Flexibility parser has sets of attributes: one power and one flh
+  attr_set:
+    power:
+      input: capacity_of_energy_hydrogen_flexibility_p2g_electricity
+      gquery: capacity_energy_hydrogen_flexibility_p2g_electricity_for_h2_chart
+      factor: 1.e-6
+    fullLoadHours:
+      input: # the flh are derived from a scenario and cannot be set
+      gquery: flh_p2g
+      factor: 1

--- a/config/conversions/assets/flexibility.yml
+++ b/config/conversions/assets/flexibility.yml
@@ -11,5 +11,5 @@
       factor: 1.e-6
     fullLoadHours:
       input: # the flh are derived from a scenario and cannot be set
-      gquery: flh_p2g
+      gquery: flh_of_energy_hydrogen_flexibility_p2g_electricity
       factor: 1

--- a/config/conversions/assets/volatile.yml
+++ b/config/conversions/assets/volatile.yml
@@ -28,7 +28,7 @@
       edr:
     fullLoadHours:
       input: flh_of_solar_pv_solar_radiation
-      gquery:
+      gquery: merit_order_energy_power_solar_pv_solar_radiation_full_load_hours_in_merit_order_table
       factor: 1
       edr:
 

--- a/config/conversions/config.yml
+++ b/config/conversions/config.yml
@@ -7,6 +7,21 @@ on_hold:
   - industry_useful_demand_for_chemical_refineries
   - industry_useful_demand_for_chemical_other
 
+  # These shouldn't be set when there are no power plant and/or industry demand
+  # assets in the ESDL file
+  - capacity_of_energy_power_combined_cycle_network_gas
+  - capacity_of_energy_power_ultra_supercritical_coal
+  - capacity_of_energy_power_supercritical_waste_mix
+  - capacity_of_industry_chp_combined_cycle_gas_power_fuelmix
+  - capacity_of_industry_chp_turbine_gas_power_fuelmix
+  - capacity_of_industry_chp_engine_gas_power_fuelmix
+  - industry_aluminium_production
+  - industry_other_metals_production
+  - industry_steel_production
+  - industry_useful_demand_for_aggregated_other
+  - industry_useful_demand_for_other_food
+  - industry_useful_demand_for_other_paper
+
   # For testing purposes I turned these off - they seem to cause many problems
   - flh_of_energy_power_wind_turbine_inland
   - flh_of_solar_pv_solar_radiation

--- a/config/conversions/config.yml
+++ b/config/conversions/config.yml
@@ -9,6 +9,4 @@ on_hold:
 
   # For testing purposes I turned these off - they seem to cause many problems
   - flh_of_energy_power_wind_turbine_inland
-  - capacity_of_energy_power_solar_pv_solar_radiation
   - flh_of_solar_pv_solar_radiation
-

--- a/tests/models/test_scenario_to_esdl_converter.py
+++ b/tests/models/test_scenario_to_esdl_converter.py
@@ -11,6 +11,7 @@ from app.models.energy_system import EnergySystemHandler
 # To mock their update methods
 from app.models.kpi_handler import KPIHandler
 from app.models.parsers.volatile import VolatileParser
+from app.models.parsers.flexibility import FlexibilityParser
 
 @pytest.fixture
 def energy_system_handler():
@@ -21,8 +22,10 @@ def energy_system_handler():
 
 
 def test_update_esdl(energy_system_handler):
+    #  !! THIS TEST IS MOCKED !!
     KPIHandler.update = MagicMock(return_value=None)
     VolatileParser.update = MagicMock(return_value=None)
+    FlexibilityParser.update = MagicMock(return_value=None)
 
     esh = update_esdl(energy_system_handler, 123456)
     assert esh


### PR DESCRIPTION
The following changes have been made:
- A parser was added for the **Electrolyzer** asset with a `parse` function (to set the ETM capacity to the ESDL value) and an `update` function (to set the ESDL full load hours to the ETM value).
- The `update` functions of the Electrolyzer and Flexibility parsers only update the full load hours. The functionality to add measures and/or remove assets is (temporarily) disabled. 
- Further, the KPIs are now only updated if a KPI container exists in the ESDL file.

No tests have been added yet. That's still to be done!

The code in [`scenario_to_esdl_converter.py`](https://github.com/quintel/etm-esdl/blob/electrolyzer/app/models/scenario_to_esdl_converter.py#L18-L31) is getting somewhat repetitive and ugly. If time permits, could you think of an elegant way to go over the update functions of all assets, @noracato?

Also, I just noticed my latest commit is failing Semaphore's tests. Couldn't quickly figure out why though. Could you help me out here @noracato?