### PR TITLE
Add ProfileHandler to add SingleValue profiles for the yearly mobility demand (in terms of volume)

### DIFF
--- a/app/models/profile_handler.py
+++ b/app/models/profile_handler.py
@@ -1,0 +1,49 @@
+"""
+Everything to do with profiles
+"""
+
+from esdl import esdl
+
+
+class ProfileHandler():
+    """
+    Handler to add or update profile based on ETM values for an ESDL asset
+    """
+    def __init__(self, asset):
+        self.asset = asset
+
+
+    def update(self, val, qu):
+        """
+        Update the SingleValue of the asset's StaticProfile
+
+        val     float, value representing the yearly (demand) volume
+        qu      QuantityAndUnitType (ESDL)
+        """
+        if not self.asset.port:
+            print(f"Warning! Yearly demand volume couldn't be added to the {self.asset} asset because no port was found.")
+
+            return
+
+        if not self.asset.port[0].profile:
+            self.__add_profile(qu)
+
+        self.asset.port[0].profile[0].value = val
+
+
+    def __add_profile(self, qu):
+        """
+        A single value is added as a static profile to the asset's inPort
+
+        TODO: Make it possible to add other types of profiles
+
+        TODO: How to deal with multiple ports? How to check if 
+        we're dealing with the correct port?
+        """
+
+        # First, add a SingleValue profile
+        yearly_demand = esdl.SingleValue(name="Yearly demand")
+        self.asset.port[0].profile.append(yearly_demand)
+
+        # Then, add quantity and units to it
+        self.asset.port[0].profile[0].profileQuantityAndUnit = qu

--- a/config/conversions/assets/demand.yml
+++ b/config/conversions/assets/demand.yml
@@ -7,12 +7,16 @@
   attr_set: 
     power:
       input: # cannot be set in the ETM
-      gquery: capacity_of_transport_car_using_hydrogen # hydrogen_cars_in_use_of_final_demand_in_cars
+      gquery: capacity_of_transport_car_using_hydrogen
       factor: 1.e-6 # gquery returns value in MW
     fullLoadHours:
       input: # the flh are derived from a scenario and cannot be set
       gquery: flh_of_transport_car_using_hydrogen
       factor: 1
+    volume:
+      input: # cannot be set in the ETM
+      gquery: hydrogen_cars_in_use_of_final_demand_in_cars
+      factor: 1.e-15 # gquery returns value in PJ
 - asset: MobilityDemand
   parser: mobility_demand # or volume?
   fuel: HYDROGEN
@@ -20,12 +24,16 @@
   attr_set: 
     power:
       input: # cannot be set in the ETM
-      gquery: capacity_of_transport_truck_using_hydrogen # hydrogen_trucks_in_use_of_final_demand_in_freight_transport_technologies
+      gquery: capacity_of_transport_truck_using_hydrogen
       factor: 1.e-6 # gquery returns value in MW
     fullLoadHours:
       input: # the flh are derived from a scenario and cannot be set
       gquery: flh_of_transport_truck_using_hydrogen
       factor: 1
+    volume:
+      input: # cannot be set in the ETM
+      gquery: hydrogen_trucks_in_use_of_final_demand_in_freight_transport_technologies
+      factor: 1.e-15 # gquery returns value in PJ
 - asset: MobilityDemand
   parser: mobility_demand # or volume?
   fuel: HYDROGEN
@@ -33,9 +41,13 @@
   attr_set:
     power:
       input: # cannot be set in the ETM
-      gquery: capacity_of_transport_van_using_hydrogen # hydrogen_vans_in_use_of_final_demand_in_freight_transport_technologies
+      gquery: capacity_of_transport_van_using_hydrogen
       factor: 1.e-6 # gquery returns value in MW
     fullLoadHours:
       input: # the flh are derived from a scenario and cannot be set
       gquery: flh_of_transport_van_using_hydrogen
       factor: 1
+    volume:
+      input: # cannot be set in the ETM
+      gquery: hydrogen_vans_in_use_of_final_demand_in_freight_transport_technologies
+      factor: 1.e-15 # gquery returns value in PJ

--- a/tests/models/parsers/test_demand.py
+++ b/tests/models/parsers/test_demand.py
@@ -7,7 +7,7 @@ import pytest
 from app.models.energy_system import EnergySystemHandler
 from app.models.esdl_to_scenario_converter import EsdlToScenarioConverter
 from app.models.parsers.demand import MobilityDemandParser
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 @pytest.fixture
 def esh_without_mobility_demand():
@@ -38,6 +38,11 @@ def mocked_values():
             'present': 0., 
             'future': 8760., 
             'unit': 'hours'
+        },
+        'hydrogen_cars_in_use_of_final_demand_in_cars': {
+            'present': 0., 
+            'future': 200., 
+            'unit': 'JOULE'
         }
     }
 
@@ -94,3 +99,7 @@ def test_parse_with_mobility_demand(esh_with_mobility_demand, app, requests_mock
     # Check if the number of FLH has been updated and if it has been 
     # set to 8760 for the first asset
     assert first_mobility_demand.fullLoadHours == 8760
+
+    # Check if the volume has been added as a SingleValue profile
+    # for the first asset
+    assert first_mobility_demand.port[0].profile[0].value == 200.e15

--- a/tests/models/test_profile_handler.py
+++ b/tests/models/test_profile_handler.py
@@ -9,7 +9,6 @@ from esdl import esdl
 
 from app.models.energy_system import EnergySystemHandler
 from app.models.profile_handler import ProfileHandler
-from app.utils.exceptions import ETMParseError
 
 
 @pytest.fixture

--- a/tests/models/test_profile_handler.py
+++ b/tests/models/test_profile_handler.py
@@ -1,0 +1,46 @@
+"""
+Tests for the profile handler, which adds or updates profiles to assets
+"""
+# pylint: disable=import-error disable=redefined-outer-name disable=missing-function-docstring
+# from unittest.mock import MagicMock
+import pytest
+
+from esdl import esdl
+
+from app.models.energy_system import EnergySystemHandler
+from app.models.profile_handler import ProfileHandler
+from app.utils.exceptions import ETMParseError
+
+
+@pytest.fixture
+def esh_without_mobility_demand():
+    """
+    Energy system based on the MMvIB macro case WITHOUT mobility demand assets
+    """
+    with open('tests/fixtures/mmvib_macro_without_demand.esdl') as file:
+        esdl_string = file.read()
+    return EnergySystemHandler.from_string(esdl_string)
+
+@pytest.fixture
+def esh_with_mobility_demand():
+    """
+    Energy system based on the MMvIB macro case WITH mobility demand assets
+    """
+    with open('tests/fixtures/mmvib_macro.esdl') as file:
+        esdl_string = file.read()
+    return EnergySystemHandler.from_string(esdl_string)
+
+
+def test_add_range_to_pv(esh_with_mobility_demand):
+    asset = next(esh_with_mobility_demand.get_all_instances_of_type_by_name('MobilityDemand'))
+
+    handler = ProfileHandler(asset)
+
+    val = 10.
+    qu = esdl.QuantityAndUnitType(
+                physicalQuantity="ENERGY",
+                unit="JOULE")
+    
+    handler.update(val, qu)
+
+    assert asset.port[0].profile[0].value == val


### PR DESCRIPTION
FYI, the ProfileHandler only adds a SingleValue profile when an inPort is present for the asset already (representing a demand).