### PR TITLE
Enable processing of PowerPlants, fix processing of ranges for Storage

### DIFF
--- a/app/models/parsers/storage.py
+++ b/app/models/parsers/storage.py
@@ -55,7 +55,7 @@ class StorageParser(CapacityParser):
             
             # If no second scenario ID is given, don't add a range to the asset
             if scenario_id_max:
-                self.__update_range(asset, "maxChargeRate", qu_power, min_power, max_power)
+                self.__update_range(asset, 'power', qu_power, min_power, max_power)
 
 
     def __update_flh(self, asset):

--- a/app/models/scenario_to_esdl_converter.py
+++ b/app/models/scenario_to_esdl_converter.py
@@ -18,7 +18,7 @@ def update_esdl(energy_system, scenario_id_min, scenario_id_max, filter=[]):
     # Update KPIs
     KPIHandler(energy_system, scenario_id_min).update()
 
-    asset_types = filter if filter else ['WindTurbine', 'PVPark', 'Electrolyzer', 'Battery', 'GasConversion','MobilityDemand', 'EnergyCarrier']
+    asset_types = filter if filter else ['WindTurbine', 'PVPark', 'Electrolyzer', 'Battery', 'GasConversion','MobilityDemand', 'EnergyCarrier', 'PowerPlant']
     assets = [asset for asset in AssetFilter.assets_for(*asset_types, method='update')]
 
     # Query ETEngine scenario's for given scenario id and assets. The GqueryCache class is a Singleton

--- a/app/models/scenario_to_esdl_converter.py
+++ b/app/models/scenario_to_esdl_converter.py
@@ -32,6 +32,10 @@ def update_esdl(energy_system, scenario_id_min, scenario_id_max, filter=[]):
     # Update FLH for wind turbines, PV parks and electrolyzers, and capacities for MobilityDemand;
     # possibly also add measures for wind turbines
     for asset in assets:
+        # Skip the carrier_capacity parser for now
+        if asset['parser'] == 'carrier_capacity':
+            continue
+
         if asset['parser'] == 'mobility_demand':
             MobilityDemandParser(energy_system, asset).update(scenario_id_min)
 


### PR DESCRIPTION
## What
This PR enables the parsing of PowerPlants and fixes the parsing/processing of `PowerRange`.`minValue` and `maxValue` of `Storage` assets (such as `Batteries`).

## Why?
It appeared these were not yet processed when exporting a scenario to ESDL

## How?
See the (small) changes of this PR.

Closes #115 